### PR TITLE
feat(classify): include owning org in classifier searchable text

### DIFF
--- a/api/cron/fetch-repos.js
+++ b/api/cron/fetch-repos.js
@@ -44,7 +44,7 @@ async function fetchOrgRepos(org, headers) {
             updated: r.pushed_at || null,
             license: r.license ? r.license.spdx_id : null,
             topics: r.topics || [],
-            ...classify({ name: r.name, desc: r.description || "", topics: r.topics || [] }),
+            ...classify({ name: r.name, desc: r.description || "", topics: r.topics || [], org: org.name }),
             org: org.name,
             category: org.category,
             country: org.country,

--- a/lib/classify.js
+++ b/lib/classify.js
@@ -31,12 +31,13 @@ const FUNCTION_RULES = [
 
 /**
  * Classify a repo by domain and function.
- * @param {{ name: string, desc: string, topics?: string[] }} repo
+ * @param {{ name: string, desc: string, topics?: string[], org?: string }} repo
  * @returns {{ domain: string, fn: string }}
  */
 export function classify(repo) {
-  // Build a single searchable string from name + description + topics.
+  // Build a single searchable string from org + name + description + topics.
   const text = [
+    repo.org || "",
     repo.name || "",
     repo.desc || "",
     ...(repo.topics || []),


### PR DESCRIPTION
## Summary

Closes #5. Passes the owning org slug into `classify()` so the UK/EU/FVEY agency keywords shipped in #4 actually match repos that are owned by those agencies but don't mention them in their own name/description/topics.

## Why this matters

The #5 body lays this out in detail, but the summary is: after #4 expanded the keyword lists with slugs like `ncsc`, `dstl`, `hmrc`, `defra`, `moj-`, verification against the 2026-04-19 cron corpus showed the keywords only matched when the repo's own metadata mentioned the agency. The org slug was never in the searchable text. So:

| Org | Repos | Expected-domain hits | Still "Other" |
|---|---|---|---|
| `dstl` | 9 | 0 | 9 |
| `ukncsc` | 5 | 2 | 3 |
| `defra` | 986 | 81 | 866 |
| `hmrc` | 1443 | 136 | 1139 |
| `moj-analytical-services` | 95 | 8 | 76 |

`ukncsc/zero-trust-architecture` is the obvious case: nothing in `{name, desc, topics}` contains `ncsc`, so the `Cybersecurity` rule can't fire even though we know it's an NCSC repo.

## Changes (exactly as proposed in the issue)

- `api/cron/fetch-repos.js` call site: add `org: org.name` to the `classify(...)` argument object.
- `lib/classify.js`:
  - Prepend `repo.org || ""` to the searchable text.
  - Update the JSDoc `@param` signature to include `org?: string`.
  - Update the inline comment to mention that org now participates.

Total: 4 additions / 3 deletions across 2 files.

## Verification

Node-level smoke check against the new behaviour:

```
$ node -e "import('./lib/classify.js').then(m => {
    console.log('without org:', m.classify({name: 'zero-trust-architecture', desc: '', topics: []}));
    console.log('with org:   ', m.classify({name: 'zero-trust-architecture', desc: '', topics: [], org: 'ukncsc'}));
  })"
without org: { domain: 'Other', fn: 'Other' }
with org:    { domain: 'Cybersecurity', fn: 'Other' }
```

The `without org` path still returns `Other` (same as today), so existing call sites that don't pass `org` are backward-compatible. The `with org` path picks up the `ncsc` keyword via the org slug and lands in `Cybersecurity`, which is the fix the issue was written for.

No test suite in the repo (`ls tests/ test/ __tests__/ 2>&1` returns nothing, `find . -name "*.test.js"` returns nothing under non-`node_modules`), so smoke verification is via `node -e` imports as above.

## Known trade-offs (from the issue's Risks section)

- `nhsdigital/infrastructure-monorepo` now classifies as Healthcare purely because `nhs` appears in the org slug. The issue rates this acceptable ("this repo belongs to a health agency").
- `hmrc/hmrc-tax-platform` gets two `hmrc` hits (org + name), boosting the Finance score. Tie-break order is rule-order-based, so this is a scale shift only.
- Generic org slugs like `city-of-x` could pick up unintended keyword hits. Worth spot-checking in the next cron diff.

Closes #5

---

This contribution was developed with AI assistance (Claude Code).
